### PR TITLE
Force using conan1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-autocxx = { version = "0.22.3" }
+autocxx = { version = "0.26.0" }
 cxx = "1.0.68"
 
 [build-dependencies]
-conan = "0.2"
-autocxx-build = { version = "0.22.3" }
-miette = { version="4.3", features=["fancy"] }
+conan = "0.3"
+autocxx-build = { version = "0.26.0" }
+miette = { version="5.9", features=["fancy"] }
+
+[lib]
+# autocxx generates some doctest-like code which fails to compile
+doctest = false

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ linking to work correctly). Make sure linking and loading is succesful with
 You will need a conan profile that matches the pattern
 `tket-rs-{os}-{platform}`, e.g. `tket-rs-linux-x86_64`. So a command like
 
-```
+```bash
 conan profile new tket-rs-linux-x86_64 --detect
 ```
 
@@ -24,7 +24,7 @@ should work.
 
 You might also need to run 
 
-```
+```bash
 conan profile update settings.compiler.libcxx=libstdc++11 tket-rs-linux-x86_64
 ```
 
@@ -33,8 +33,8 @@ Now go check that profile, crucially you need to make sure compiler version is
 11, compiler is gcc, and build_type is Release.
 
 
-Here is an example: 
-```
+Here is an example for a linux profile: 
+```toml
 [settings]
 os=Linux
 os_build=Linux
@@ -49,6 +49,10 @@ build_type=Release
 [env]
 ```
 
+Finally, make sure to add the remote with the tket pre-compiled binaries:
+```bash
+conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+```
 
 ## Troubleshooting
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use conan::*;
 
-use std::path::{Path, PathBuf};
 use std::env;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
@@ -22,12 +22,12 @@ fn main() {
     let mut cxx_includes: Vec<_> = build_info
         .dependencies()
         .iter()
-        .filter_map(|dep| dep.get_include_dir().map(|dir| PathBuf::from(dir)))
+        .filter_map(|dep| dep.get_include_dir().map(PathBuf::from))
         .collect();
     for c in build_info
         .dependencies()
         .iter()
-        .filter_map(|dep| dep.get_library_dir().map(|dir| PathBuf::from(dir)))
+        .filter_map(|dep| dep.get_library_dir().map(PathBuf::from))
     {
         println!("cargo:rustc-link-search={}", c.display());
         // loader_s.push_str(&format!(":{}", c.display())[..]);

--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,7 @@ fn main() {
         .define("BOOST_ALLOW_DEPRECATED_HEADERS", "ON")
         .file("src/unitary.cpp")
         .flag("-std=c++17")
+        .flag("-w") // Ignore warnings from tket (and symengine)
         .opt_level(1)
         .compile("tket-rs");
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-conan
+conan==1.60.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// Ignore generated code
+#![allow(clippy::all)]
+#![allow(unknown_lints)]
+
 use autocxx::include_cpp;
 // pub mod tkbind {
 include_cpp! {


### PR DESCRIPTION
- Pins conan to the last version before 2.0. The rust crate `conan` does not support conan2.
- Updates the deps.
- Updates the README to indicate conan's artifactory remote configuration.
- Disables lints so clippy and `cargo check` run without warnings.
